### PR TITLE
feat: added support for KMS key in IAM policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ A Terraform Module for configuring an integration with Lacework and AWS for Clou
 | tags | A map/dictionary of Tags to be assigned to created resources | `map(string)` | `{}` | no |
 | use\_existing\_iam\_role | Set this to true to use an existing IAM role | `bool` | `false` | no |
 | wait\_time | Amount of time to wait before the next resource is provisioned. | `string` | `"10s"` | no |
+| kms\_key\_arn | Control Tower KMS key arn | `string` | `""` | no |
+
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "sns_topic_arn" {
 }
 
 variable "s3_bucket_arn" {
-  type = string
+  type        = string
   description = "The ARN for the  S3 bucket for consolidated CloudTrail logging. Usually in the form like: arn:aws:s3:::aws-controltower-logs-<log_archive_account_id>-<control_tower_region>"
 }
 
@@ -95,4 +95,10 @@ variable "tags" {
   type        = map(string)
   description = "A map/dictionary of Tags to be assigned to created resources"
   default     = {}
+}
+
+variable "kms_key_arn" {
+  type        = string
+  default     = ""
+  description = "The KMS key arn, if Control Tower was deployed with custom KMS key"
 }


### PR DESCRIPTION
## Summary

If Control Tower configured to use KMS key, IAM policy and key resource policy needs to be updated. Key resource policy is not managed by this module. However IAM policy is managed here. currently the only way is to modify policy manually, and this approach leads to drift between terraform code and actual state

## How did you test this change?

added a variable `kms_key_arn`. and using `iam_policy_document` source policy feature - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#example-of-merging-source-documents 

we dynamically construct the policy that will include KMS decrypt permission only if `kms_key_arn` was specified


