### PR TITLE
Sqsfix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,8 @@ resource "aws_sqs_queue_policy" "lacework_sqs_queue_policy" {
 			},
 			"Action": [
 				"sqs:DeleteMessage",
-				"sqs:ReceiveMessage"
+				"sqs:ReceiveMessage",
+                "sqs:GetQueueAttributes"
 			      ],
 			"Resource": "${aws_sqs_queue.lacework_cloudtrail_sqs_queue.arn}"
 		}

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ locals {
     length(var.iam_role_name) > 0 ? var.iam_role_name : "${var.prefix}-iam-${random_id.uniq.hex}"
   )
 }
-
+x
 data "aws_organizations_organization" "main" {
   provider = aws.audit
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  sqs_queue_name  = length(var.sqs_queue_name) > 0 ? var.sqs_queue_name : "${var.prefix}-sqs-${random_id.uniq.hex}"
+  sqs_queue_name   = length(var.sqs_queue_name) > 0 ? var.sqs_queue_name : "${var.prefix}-sqs-${random_id.uniq.hex}"
   s3_logs_location = "${var.s3_bucket_arn}/${data.aws_organizations_organization.main.id}/*AWSLogs/*"
   cross_account_policy_name = (
     length(var.cross_account_policy_name) > 0 ? var.cross_account_policy_name : "${var.prefix}-cross-acct-policy-${random_id.uniq.hex}"
@@ -21,53 +21,53 @@ resource "random_id" "uniq" {
 
 resource "aws_sqs_queue" "lacework_cloudtrail_sqs_queue" {
   provider = aws.audit
-  name = local.sqs_queue_name
-  tags = var.tags
+  name     = local.sqs_queue_name
+  tags     = var.tags
 }
 
 resource "aws_sqs_queue_policy" "lacework_sqs_queue_policy" {
-  provider = aws.audit
+  provider   = aws.audit
   depends_on = [time_sleep.wait_time]
-  queue_url = aws_sqs_queue.lacework_cloudtrail_sqs_queue.id
-  policy    = <<POLICY
+  queue_url  = aws_sqs_queue.lacework_cloudtrail_sqs_queue.id
+  policy     = <<POLICY
 {
-	"Version": "2012-10-17",
-	"Id": "lacework_sqs_policy_${random_id.uniq.hex}",
-	"Statement": [
-		{
-			"Sid": "AllowLaceworkSNSTopicToSendMessage",
-			"Effect": "Allow",
-			"Principal": {
-				"AWS": "*"
-			},
-			"Action": "SQS:SendMessage",
-			"Resource": "${aws_sqs_queue.lacework_cloudtrail_sqs_queue.arn}",
-			"Condition": {
-				"ArnEquals": {
-					"aws:SourceArn": "${var.sns_topic_arn}"
-				}
-			}
-		},
-		{
-			"Sid": "AllowLaceworkCrossAccountRoleToAccessSQSQueue",
-			"Effect": "Allow",
-			"Principal": {
-				"AWS": "${local.iam_role_arn}"
-			},
-			"Action": [
-				"sqs:DeleteMessage",
-				"sqs:ReceiveMessage",
-                "sqs:GetQueueAttributes"
-			      ],
-			"Resource": "${aws_sqs_queue.lacework_cloudtrail_sqs_queue.arn}"
-		}
-	]
+  "Version": "2012-10-17",
+  "Id": "lacework_sqs_policy_${random_id.uniq.hex}",
+  "Statement": [
+    {
+      "Sid": "AllowLaceworkSNSTopicToSendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "SQS:SendMessage",
+      "Resource": "${aws_sqs_queue.lacework_cloudtrail_sqs_queue.arn}",
+      "Condition": {
+        "ArnEquals": {
+          "aws:SourceArn": "${var.sns_topic_arn}"
+        }
+      }
+    },
+    {
+      "Sid": "AllowLaceworkCrossAccountRoleToAccessSQSQueue",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${local.iam_role_arn}"
+      },
+      "Action": [
+        "sqs:DeleteMessage",
+        "sqs:ReceiveMessage",
+        "sqs:GetQueueAttributes"
+            ],
+      "Resource": "${aws_sqs_queue.lacework_cloudtrail_sqs_queue.arn}"
+    }
+  ]
 }
 POLICY
 }
 
 resource "aws_sns_topic_subscription" "lacework_sns_topic_sub" {
-  provider = aws.audit
+  provider  = aws.audit
   topic_arn = var.sns_topic_arn
   protocol  = "sqs"
   endpoint  = aws_sqs_queue.lacework_cloudtrail_sqs_queue.arn
@@ -75,8 +75,8 @@ resource "aws_sns_topic_subscription" "lacework_sns_topic_sub" {
 
 data "aws_iam_policy_document" "cross_account_policy" {
   provider = aws.log_archive
-  version = "2012-10-17"
-  
+  version  = "2012-10-17"
+
   statement {
     sid       = "ReadLogFiles"
     actions   = ["s3:Get*"]
@@ -135,7 +135,7 @@ data "aws_iam_policy_document" "cross_account_policy" {
 }
 
 resource "aws_iam_policy" "cross_account_policy" {
-  provider = aws.log_archive
+  provider    = aws.log_archive
   name        = local.cross_account_policy_name
   description = "A cross account policy to allow Lacework to pull config and cloudtrail"
   policy      = data.aws_iam_policy_document.cross_account_policy.json

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ locals {
     length(var.iam_role_name) > 0 ? var.iam_role_name : "${var.prefix}-iam-${random_id.uniq.hex}"
   )
 }
-x
+
 data "aws_organizations_organization" "main" {
   provider = aws.audit
 }


### PR DESCRIPTION
## Summary

For AWS ControlTower integration using SSO, "sqs:GetQueueAttributes" is required. While as of 0.15 this permission is added to the cross account role policy, it has not yet been added to the SQS Access Policy, causing CloudTrail integration to encounter 403 errors.

## How did you test this change?

Replicated issue in personal account and ControlTower using SSO, updated Access Policy for SQS queue manually to add sqs:GetQueueAttributes permission for the cross account role and CloudTrail integration began populating without errors.

## Issue

N/A