### PR TITLE
Updated SQS Access Policy document to add GetQueueAttributes permissi…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,8 @@ resource "aws_sqs_queue_policy" "lacework_sqs_queue_policy" {
 			},
 			"Action": [
 				"sqs:DeleteMessage",
-				"sqs:ReceiveMessage"
+				"sqs:ReceiveMessage",
+                "sqs:GetQueueAttributes"
 			      ],
 			"Resource": "${aws_sqs_queue.lacework_cloudtrail_sqs_queue.arn}"
 		}


### PR DESCRIPTION
## Summary

For AWS ControlTower integration using SSO, "sqs:GetQueueAttributes" is required. While as of 0.15 this permission is added to the cross account role policy, it has not yet been added to the SQS Access Policy, causing CloudTrail integration to encounter 403 errors.

## How did you test this change?

Replicated issue in personal account and ControlTower using SSO, updated Access Policy for SQS queue manually to add sqs:GetQueueAttributes permission for the cross account role and CloudTrail integration began populating without errors.

## Issue

N/A