### PR TITLE
docs: Adds required organization argument in lacework provider block

### DIFF
--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -1,6 +1,10 @@
 # This example assumes that Lacework CLI has been set up.  
 
 ```hcl
+provider "lacework" {
+  organization = true
+}
+
 provider "aws" {
   alias  = "log_archive"
   # profile  = "<profile name for log_archive account in ~/.aws/credentials>"

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,3 +1,7 @@
+provider "lacework" {
+  organization = true
+}
+
 provider "aws" {
   alias  = "log_archive"
   profile  = "287453222145_AWSAdministratorAccess"


### PR DESCRIPTION
GROW-1372

## Summary

When using `terraform-aws-cloudtrail-controltower` template without "organization" var set to true, the following error will be generated:

`│ Error: Error creating AwsCtSqs cloud account integration:
│ [POST] https://<tenant>.lacework.net/api/v2/CloudAccounts
│ [400] AccountMappingFile or AccountMapping is for Org Level aws CloudTrail Integration only.`

The submitted change to our example code includes a provider block that will meet this prerequisite and avoid customers encountering the above error when following our code example. Considering that the purpose of the template stipulates the use of ControlTower, this prerequisite will be true for all feasible use-cases as it is only applicable to org trails.

## How did you test this change?

Provided and confirmed solution in customer support issue #10388, associated with https://lacework.atlassian.net/browse/GROW-1372

## Issue

Template has dependency of `lacework/lacework ~> 1.0` for module and `organization` boolean must be set to true to provide access to org API features or return the error above. Including the provide block in our example code will avoid customer confusion when using the example.
