### PR TITLE
chore: allow AWS provider >= v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Terraform Module for configuring an integration with Lacework and AWS for Clou
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0, < 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 | <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.1 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.6 |
@@ -22,8 +22,8 @@ A Terraform Module for configuring an integration with Lacework and AWS for Clou
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.audit"></a> [aws.audit](#provider\_aws.audit) | >= 3.0, < 5.0.0 |
-| <a name="provider_aws.log_archive"></a> [aws.log\_archive](#provider\_aws.log\_archive) | >= 3.0, < 5.0.0 |
+| <a name="provider_aws.audit"></a> [aws.audit](#provider\_aws.audit) | >= 3.0 |
+| <a name="provider_aws.log_archive"></a> [aws.log\_archive](#provider\_aws.log\_archive) | >= 3.0 |
 | <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.1 |
 | <a name="provider_time"></a> [time](#provider\_time) | ~> 0.6 |

--- a/versions.tf
+++ b/versions.tf
@@ -2,9 +2,9 @@ terraform {
   required_version = ">= 0.15.1"
 
   required_providers {
-    aws    = {
-      source = "hashicorp/aws"
-      version = ">= 3.0, < 5.0.0"
+    aws = {
+      source                = "hashicorp/aws"
+      version               = ">= 3.0"
       configuration_aliases = [aws.audit, aws.log_archive]
     }
     random = ">= 2.1"


### PR DESCRIPTION
We are not aware of any limitation.

https://lacework.atlassian.net/browse/LINK-2317
