### PR TITLE
feat: Add lacework_ingration_guid as output

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ A Terraform Module for configuring an integration with Lacework and AWS for Clou
 | <a name="output_external_id"></a> [external\_id](#output\_external\_id) | The External ID configured into the IAM role |
 | <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | The IAM Role ARN |
 | <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | The IAM Role name |
+| <a name="output_lacework_integration_guid"></a> [lacework\_integration\_guid](#output\_lacework\_integration\_guid) | Lacework CloudTrail Integration GUID |
 | <a name="output_sns_arn"></a> [sns\_arn](#output\_sns\_arn) | SNS Topic ARN |
 | <a name="output_sqs_arn"></a> [sqs\_arn](#output\_sqs\_arn) | SQS Queue ARN |
 | <a name="output_sqs_name"></a> [sqs\_name](#output\_sqs\_name) | SQS Queue name |

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ locals {
     length(var.iam_role_name) > 0 ? var.iam_role_name : "${var.prefix}-iam-${random_id.uniq.hex}"
   )
   version_file   = "${abspath(path.module)}/VERSION"
+  lacework_integration_guid = lacework_integration_aws_ct.default.id
   module_name    = "terraform-aws-cloudtrail-controltower"
   module_version = fileexists(local.version_file) ? file(local.version_file) : ""
 }

--- a/output.tf
+++ b/output.tf
@@ -32,3 +32,8 @@ output "iam_role_arn" {
   value       = local.iam_role_arn
   description = "The IAM Role ARN"
 }
+
+output "lacework_integration_guid" {
+  value       = local.lacework_integration_guid
+  description = "Lacework CloudTrail Integration GUID"
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail-controltower/blob/main/CONTRIBUTING.md
--->

## Summary

Add lacework_ingration_guid as output. Self-deployment will use this field to track integration.

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->
